### PR TITLE
split social landing page

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Twitter
+title: Social Media
 ---
 
 ##### Table of Contents  
@@ -13,11 +13,8 @@ Twitter
 * [twarc](#twarc)  
 * [Twitter API v2](#v2)   
 * [Ncapture](https://chrome.google.com/webstore/detail/ncapture/lgomjifbpjfhpodjhihemafahhmegbek)
-<br>
-Other Pre-existing Datasets
-
  
-This page is an index (parent repo) for all of our current projects concerning Twitter and relevant information. Click on the headers to be take to a short summary about the corresponding topic. Or, if you'd like to be taken straight to a project's repo, click the repo link under the header. 
+This page is an index of our current projects concerning using social media for academic research. We also have a page with [links to other sites of interest](social_media_links.md)
 
 <a name="monitoring"/>    
 
@@ -47,23 +44,4 @@ This page is an index (parent repo) for all of our current projects concerning T
 - A chrome browser plugin that will capture tweets in a format usable in Nvivo qualitative data analysis software. 
 
 
-## [Document the Now](https://catalog.docnow.io/)
-- A catalog of more than 100 datasets totalling more than 4 billion tweet IDs 
 
-## Internet Archive 
-- [Nipsey Hussle Death Tweet Archive](https://archive.org/details/nipsey-hustle-tweets)
-- [Obama White House Twitter Archives](https://archive.org/details/ObamaWhiteHouseTwitterArchive)
-- [University of North Carolina Confederate Monument Protests 2017 - 2019](https://dcr.lib.unc.edu/record/3551adaa-5b88-4460-8e0d-e661a204442a)
-
-## [Harvard CGA Geotweet Archive v2.0](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/3NCMB6)
--Extending back to 2010, and updated daily, the Harvard Center for Geographic Analysis (CGA) contains more than 10 billion tweets. Extractions require reimbursement from CGA
-
-## [Reddit APIs](https://www.reddit.com/dev/api/)
-- Access data from posts, threads, comments, users, and more from Reddit and subreddits. Historical Reddit data has been collected as [monthly csv downloads](http://files.pushshift.io/reddit/)
-
-## [Yelp API](https://docs.developer.yelp.com/docs/getting-started)
-- Access to business data, including location, photos, Yelp ratings, price levels, hours of operation, and types of transactions. 
-- Also includes Review API, which returns up to 3 review excerpts for a business 
-
-## [Stanford Large Network Dataset Collection (SNAP)](http://snap.stanford.edu/data/index.html)
-- The SNAP library collects data on large social and information networks since 2004 

--- a/other_resources.md
+++ b/other_resources.md
@@ -1,0 +1,30 @@
+---
+layout: page
+title: Links to Social Media Research Resources
+---
+
+Links to non-UCSB resources for Twitter and other online social network
+resources.
+
+# Twitter
+## [Document the Now](https://catalog.docnow.io/)
+- A catalog of more than 100 datasets totalling more than 4 billion tweet IDs 
+
+## Internet Archive 
+- [Nipsey Hussle Death Tweet Archive](https://archive.org/details/nipsey-hustle-tweets)
+- [Obama White House Twitter Archives](https://archive.org/details/ObamaWhiteHouseTwitterArchive)
+- [University of North Carolina Confederate Monument Protests 2017 - 2019](https://dcr.lib.unc.edu/record/3551adaa-5b88-4460-8e0d-e661a204442a)
+
+## [Harvard CGA Geotweet Archive v2.0](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/3NCMB6)
+-Extending back to 2010, and updated daily, the Harvard Center for Geographic Analysis (CGA) contains more than 10 billion tweets. Extractions require reimbursement from CGA
+
+# Other Social Networks
+## [Reddit APIs](https://www.reddit.com/dev/api/)
+- Access data from posts, threads, comments, users, and more from Reddit and subreddits. Historical Reddit data has been collected as [monthly csv downloads](http://files.pushshift.io/reddit/)
+
+## [Yelp API](https://docs.developer.yelp.com/docs/getting-started)
+- Access to business data, including location, photos, Yelp ratings, price levels, hours of operation, and types of transactions. 
+- Also includes Review API, which returns up to 3 review excerpts for a business 
+
+## [Stanford Large Network Dataset Collection (SNAP)](http://snap.stanford.edu/data/index.html)
+- The SNAP library collects data on large social and information networks since 2004 


### PR DESCRIPTION
This PR splits the landing page in two, with external resources on one page, and internal resources all linked from https://github.com/ucsb-dreamlab/socialmedia/issues/5